### PR TITLE
question(Q0013): add EC2 cannot access S3 with networking explanation and references

### DIFF
--- a/weeks/week-00-internet-networking-tools/README.md
+++ b/weeks/week-00-internet-networking-tools/README.md
@@ -10,9 +10,4 @@
 | Q0011 | Understanding CIDR — how IP address ranges work | entry | cidr, ip, networking, subnetting | [Open](questions/Q0011-understanding-cidr.md) |
 | Q0013 | EC2 Cannot Access S3 — Missing Networking Component | entry | ec2, s3, networking, vpc, troubleshooting | [Open](questions/Q0013-ec2-cannot-access-s3.md) |
 
-## Index
-| ID | Title | Difficulty | Tags | Link |
-|---|---|---|---|---|
-| Q0001 | OSI vs TCP/IP — what’s the practical difference? | entry | networking, osi, tcpip | [Open](questions/Q0001-osi-model-vs-tcpip.md) |
-| Q0010 | Understanding Ports — what they are and why they matter | entry | tcp, udp, ports, networking | [Open](questions/Q0010-port-with-examples.md) |
-| Q0011 | Understanding CIDR — how IP address ranges work | entry | cidr, ip, networking, subnetting | [Open](questions/Q0011-understanding-cidr.md) |
+

--- a/weeks/week-00-internet-networking-tools/README.md
+++ b/weeks/week-00-internet-networking-tools/README.md
@@ -8,6 +8,7 @@
 | Q0001 | OSI vs TCP/IP — what’s the practical difference? | entry | networking, osi, tcpip | [Open](questions/Q0001-osi-model-vs-tcpip.md) |
 | Q0010 | Understanding Ports — what they are and why they matter | entry | tcp, udp, ports, networking | [Open](questions/Q0010-port-with-examples.md) |
 | Q0011 | Understanding CIDR — how IP address ranges work | entry | cidr, ip, networking, subnetting | [Open](questions/Q0011-understanding-cidr.md) |
+| Q0013 | EC2 Cannot Access S3 — Missing Networking Component | entry | ec2, s3, networking, vpc, troubleshooting | [Open](questions/Q0013-ec2-cannot-access-s3.md) |
 
 ## Index
 | ID | Title | Difficulty | Tags | Link |

--- a/weeks/week-00-internet-networking-tools/questions/Q0013-ec2-cannot-access-s3.md
+++ b/weeks/week-00-internet-networking-tools/questions/Q0013-ec2-cannot-access-s3.md
@@ -1,0 +1,47 @@
+---
+id: Q0013
+title: EC2 Cannot Access S3 — Missing Networking Component
+difficulty: entry
+week: 00
+topics: networking, aws, vpc, s3]
+tags: [ec2, s3, networking, vpc, troubleshooting]
+author: "[Hajixhayjhay](https://github.com/Hajixhayjhay)"
+reviewed: false
+---
+
+## Question
+- Your EC2 instance cannot access an S3 bucket. What networking component could be missing?
+
+## Short Answer
+- Most likely a **VPC Endpoint** (Gateway Endpoint for S3) is missing, or the EC2 instance has no **Internet Gateway/NAT Gateway** for public S3 access.  
+
+
+## Deep Dive
+- **VPC Endpoint for S3:**  
+  - Allows private communication between EC2 and S3 without going over the public internet.  
+  - Check if a Gateway Endpoint exists for the correct route table.  
+
+- **Internet or NAT Gateway:**  
+  - If the EC2 is in a private subnet, it needs a NAT Gateway to access S3 over the internet.  
+  - Public subnet EC2s need an Internet Gateway attached to the VPC.
+
+- **Security Groups & NACLs:**  
+  - Ensure outbound rules allow traffic to S3 endpoints or the internet.
+
+- **Testing:**  
+```bash
+curl https://<bucket-name>.s3.amazonaws.com
+
+```
+If it fails, verify subnet routing and endpoint configuration.
+
+## Pitfalls
+- Confusing security groups with network connectivity issues.
+- Assuming S3 access always requires public internet.
+- Forgetting route table associations with the VPC Endpoint.
+
+## References
+- [AWS VPC Endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html)
+- [S3 Access from VPC](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html)
+- [AWS NAT Gateway Documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html)
+

--- a/weeks/week-06-terraform/README.md
+++ b/weeks/week-06-terraform/README.md
@@ -6,5 +6,6 @@
 | ID | Title | Difficulty | Tags | Link |
 |---|---|---|---|---|
 | Q0601 | Terraform remote state, backends, and locking | medium | terraform, state, s3, dynamodb, backend | [Open](questions/Q0601-terraform-state-backends-locking.md) |
+| Q0627 | Terraform remote backend state locking | medium | terraform, backend, state-locking | [Open](questions/Q0627-terraform-remote-backend-state-locking.md) |
 | Q0655 | Terraform remote state, backends, and locking | medium | terraform, state, s3, dynamodb, backend | [Open](questions/Q0655-terraform-state-locking-and-consistency.md) |
-
+| Q0655 | Terraform Remote State, Backends, and Locking | medium | terraform, state, s3, dynamodb, backend | [Open](questions/Q0655-terraform-state-locking.md) |


### PR DESCRIPTION
## Summary
Added Q0013: EC2 cannot access S3 — explains the missing networking components, including VPC endpoints, NAT gateways, and route tables.

## Files Changed
- weeks/week-00-internet-networking-tools/questions/Q0013-ec2-cannot-access-s3.md


## Validation
- Frontmatter validated with `python scripts/validate_frontmatter.py`
- Index rebuilt with `python scripts/build_index.py`

## Notes for Reviewers
- Check that deep dive steps are correct
- Verify clickable references work