### PR TITLE
Q0301 terraform state locking

### DIFF
--- a/04-aws/questions/Q0101-iam-role-vs-user-deep-dive.md
+++ b/04-aws/questions/Q0101-iam-role-vs-user-deep-dive.md
@@ -1,0 +1,47 @@
+---
+id: Q0101
+title: IAM role vs IAM user — when and why does it matter at scale?
+difficulty: hard
+week: 01
+topics: [aws, iam, security]
+tags: [aws, iam, least-privilege, security]
+author: JulietChinenyeDuru
+reviewed: false
+---
+
+## Short Answer
+IAM users are long-lived identities with static credentials; IAM roles issue short-lived, auto-rotating tokens assumed by services, humans, or cross-account principals. At scale, users become a credential management liability — roles are the secure default.
+
+## Deep Dive
+IAM roles use STS (Security Token Service) to issue temporary credentials (15 min–12 hrs). This eliminates the risk of leaked long-term access keys.
+
+Key patterns:
+
+**EC2 instance profiles** — attach a role to an EC2 instance; applications call the metadata endpoint (`169.254.169.254`) for credentials automatically.
+
+**EKS IRSA** (IAM Roles for Service Accounts) — binds a Kubernetes service account to an IAM role via OIDC, giving pods fine-grained AWS access without node-level permissions.
+
+**Cross-account roles** — a central tooling account assumes roles in spoke accounts, enabling centralised CI/CD pipelines without distributing credentials.
+
+Auditing: CloudTrail logs `AssumeRole` events with the full chain of assumed principals, making forensics far cleaner than shared IAM user keys.
+
+```bash
+# Check what credentials your environment is using
+aws sts get-caller-identity
+
+# Assume a role manually
+aws sts assume-role \
+  --role-arn arn:aws:iam::123456789012:role/MyRole \
+  --role-session-name debug-session
+```
+
+## Pitfalls
+- Creating IAM users for CI/CD pipelines instead of using OIDC federation (GitHub Actions → AWS via OIDC needs zero stored secrets)
+- Over-broad trust policies on roles (`"Principal": "*"`) — anyone can assume them
+- Forgetting that role session duration limits affect long-running jobs (default 1hr, max 12hrs)
+- Using `AdministratorAccess` for convenience — enforce least privilege with IAM Access Analyzer
+
+## References
+- https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+- https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+- https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html

--- a/06-terraform/questions/Q0301-terraform-state-locking.md
+++ b/06-terraform/questions/Q0301-terraform-state-locking.md
@@ -1,0 +1,56 @@
+---
+id: Q0301
+title: How does Terraform state locking work and what happens when it breaks?
+difficulty: hard
+week: 03
+topics: [terraform, iac, state-management]
+tags: [terraform, state, locking, s3, dynamodb, backend]
+author: JulietChinenyeDuru
+reviewed: false
+---
+
+## Short Answer
+Terraform uses a state lock to prevent concurrent applies from corrupting infrastructure state. With an S3 + DynamoDB backend, S3 stores the state file and DynamoDB holds the lock record. A broken lock requires manual intervention to avoid split-brain infrastructure.
+
+## Deep Dive
+When you run `terraform apply`, Terraform:
+1. Acquires a lock (writes a record to DynamoDB with a `LockID`)
+2. Reads current state from S3
+3. Plans and applies changes
+4. Writes updated state back to S3
+5. Releases the lock (deletes the DynamoDB record)
+
+If a process crashes mid-apply, the lock remains. This causes `Error: Error locking state` for all subsequent runs.
+
+**Backend config:**
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "my-tf-state"
+    key            = "prod/terraform.tfstate"
+    region         = "eu-west-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}
+```
+
+**Force-unlock (use with extreme caution):**
+```bash
+# Get the Lock ID from the error message
+terraform force-unlock <LOCK_ID>
+```
+
+**State file corruption recovery:**
+- S3 versioning must be enabled — roll back with `aws s3api get-object --version-id`
+- Never edit state files manually unless using `terraform state` subcommands
+
+## Pitfalls
+- Running `terraform force-unlock` when another legitimate apply is in progress — causes state corruption
+- Not enabling S3 versioning — no recovery path if state is corrupted
+- Sharing one state file across environments — use workspaces or separate backends per environment
+- Using local state in CI/CD — no locking, no shared visibility, guaranteed drift
+
+## References
+- https://developer.hashicorp.com/terraform/language/settings/backends/s3
+- https://developer.hashicorp.com/terraform/cli/commands/force-unlock


### PR DESCRIPTION
## Summary
Added Q0301 Terraform state locking with S3 and DynamoDB backend. New question for Week 03 IaC with Short Answer, Deep Dive, Pitfalls, and References sections.

## Checklist
- [x] Uses file name `Q0301-terraform-state-locking.md`
- [x] Front matter complete and valid
- [x] Short Answer + Deep Dive + Pitfalls + References
- [ ] Ran `python scripts/validate_frontmatter.py && python scripts/build_index.py`
- [x] References are reputable

## Notes for Reviewers
Scripts validate_frontmatter.py and build_index.py are not yet present in the repo, so local validation was skipped.
