### PR TITLE
add pre-ready skill with pre-commit hook for secret and size validation

### DIFF
--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: pr-ready
+description: Reviews staged Git changes and drafts a PR title, description, and risk report. Never commits, pushes, or opens PRs.
+allowed-tools: Bash, Read, Grep
+disable-model-invocation: true
+---
+ 
+You are reviewing staged changes before a Pull Request is opened.
+1. Run `git diff --cached` and `git status` to see exactly what is staged.
+2. Report any of the following if present: secrets or credential-shaped
+strings, debug print/echo statements, TODO/FIXME left in code, a diff
+that mixes unrelated concerns, or a change with no corresponding notes.
+3. Draft a PR title that starts with a short word like `feat:` or `fix:`
+telling the reader what kind of change this is, and a 3-5 sentence PR
+description explaining what changed and why.
+4. Never run `git commit`, `git push`, or `gh pr create`. Never edit files.
+Your output is a draft for a human to review and use.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/bash
+# hooks/pre-commit — blocks commits with likely secrets or oversized files
+set -e
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+blocked=0
+for file in $staged; do
+if git diff --cached -- "$file" | grep -qE 'AKIA[0-9A-Z]{16}|-----BEGIN (RSA|OPENSSH|PRIVATE) KEY-----'; then
+echo "BLOCKED: possible secret in $file"
+blocked=1
+fi
+ 
+size=$(git cat-file -s "$(git rev-parse ":$file")" 2>/dev/null || echo 0)
+if [ "$size" -gt 1000000 ]; then
+echo "BLOCKED: $file is $(($size / 1000000))MB — over the 1MB limit"
+blocked=1
+fi
+ 
+done
+ 
+if [ "$blocked" -eq 1 ]; then
+echo "Commit rejected. Fix the issues above and try again."
+exit 1
+fi

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# demo only — fake credential for this assignment, never a real key
+


### PR DESCRIPTION
Adds a new '/pr-ready' skill that helps developers review staged Git changes before opening a pull request. The skill validates commits for common issues: credential strings (AWS keys, private key headers) , oversized files (>1MB), debug statements, and mixed concerns. Includes a corresponding pre-hook commit hook ('hooks/pre-commit')
that automatically blocks commits containing likely secrets or files exceeding the 1MB size limit, reducing the risk of accidentally committing sensitive data or large binaries.

